### PR TITLE
IPFinder: handle NULL ifaddrs.ifa_addr

### DIFF
--- a/src/cpp/utils/IPFinder.cpp
+++ b/src/cpp/utils/IPFinder.cpp
@@ -120,6 +120,10 @@ bool IPFinder::getIPs(std::vector<info_IP>* vec_name )
 
 	for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
 	{
+
+		if (ifa->ifa_addr == NULL)
+			continue;
+
 		family = ifa->ifa_addr->sa_family;
 
 		if (family == AF_INET)


### PR DESCRIPTION
The list of interfaces returned by getifaddrs() can contain a struct ifaddrs
with NULL ifa_addr. This change skips such interfaces.

A NULL ifa_addr has been observed with a tun device on linux; the returned
list looks something like this:

ifa=0x14d6ad0 ifa_name=lo ifa->flags=0x00010049
 ifa_addr=0x14d6b08 sa_family=AF_PACKET
 ifa_netmask=(nil)
 ifa_dstaddr=0x14d6b50 sa_family=AF_PACKET
 ifa_data=0x14d6e68 ifa_next=0x14d6b88

ifa=0x14d6b88 ifa_name=tun1 ifa->flags=0x000110d1
 ifa_addr=(nil)
 ifa_netmask=(nil)
 ifa_dstaddr=(nil)
 ifa_data=0x14d6ec4 ifa_next=0x14d6c40

ifa=0x14d6c40 ifa_name=lo ifa->flags=0x00010049
 ifa_addr=0x14d6c78 sa_family=AF_INET
 ifa_netmask=0x14d6c9c sa_family=AF_INET
 ifa_dstaddr=0x14d6cc0 sa_family=AF_INET
 ifa_data=(nil) ifa_next=0x14d6cf8

ifa=0x14d6cf8 ifa_name=tun1 ifa->flags=0x000110d1
 ifa_addr=0x14d6d30 sa_family=AF_INET
 ifa_netmask=0x14d6d54 sa_family=AF_INET
 ifa_dstaddr=0x14d6d78 sa_family=AF_INET
 ifa_data=(nil) ifa_next=0x14d6db0

ifa=0x14d6db0 ifa_name=lo ifa->flags=0x00010049
 ifa_addr=0x14d6de8 sa_family=AF_INET6
 ifa_netmask=0x14d6e0c sa_family=AF_INET6
 ifa_dstaddr=(nil)
 ifa_data=(nil) ifa_next=(nil)
